### PR TITLE
remove dependancy

### DIFF
--- a/INSS.EIIR.AzureSearch.API/Properties/launchSettings.json
+++ b/INSS.EIIR.AzureSearch.API/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
@@ -11,7 +11,6 @@
   "profiles": {
     "INSS.EIIR.AzureSearch.API": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7158;http://localhost:5158",

--- a/INSS.EIIR.Web/INSS.EIIR.Web.csproj
+++ b/INSS.EIIR.Web/INSS.EIIR.Web.csproj
@@ -30,8 +30,6 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.SEOHelper" Version="1.0.1" />
-    <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-    <PackageReference Include="BuildWebCompiler" Version="1.12.405" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
   </ItemGroup>
 

--- a/INSS.EIIR.Web/Properties/launchSettings.json
+++ b/INSS.EIIR.Web/Properties/launchSettings.json
@@ -3,10 +3,10 @@
     "INSS.EIIR.Web": {
       "commandName": "Project",
       "launchBrowser": true,
+      "applicationUrl": "https://localhost:57813;http://localhost:57814",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:57813;http://localhost:57814"
+      }
     }
   }
 }


### PR DESCRIPTION
Remove the nuget packages for madskristensen/WebCompiler.

The result is at the moment our deployment will not be minified.  Webcompiler had a dependancy on cmd.exe which restricted it to windows hosts only.