### PR TITLE
APP-4897 Remove un-reference properties from Search Model, change nam…

### DIFF
--- a/INSS.EIIR.Models/AutoMapperProfiles/IndividualSearchMapper.cs
+++ b/INSS.EIIR.Models/AutoMapperProfiles/IndividualSearchMapper.cs
@@ -32,6 +32,8 @@ public class IndividualSearchMapper : Profile
             .ForMember(dest => dest.InsolvencyType, opt => opt.MapFrom(src => src.insolvencyType))
             .ForMember(dest => dest.NotificationDate, opt => opt.MapFrom(src => src.notificationDate))
             .ForMember(dest => dest.CaseStatus, opt => opt.MapFrom(src => src.caseStatus))
+            .ForMember(dest => dest.CaseDescription, opt => opt.MapFrom(src => src.caseDescription))
+            .ForMember(dest => dest.TradingData, opt => opt.MapFrom(src => src.tradingNames))
             .ForMember(dest => dest.InsolvencyDate, opt => opt.MapFrom(src => src.insolvencyDate))
             .ForMember(dest => dest.HasRestrictions, opt => opt.MapFrom(src => src.hasRestrictions))
             .ForMember(dest => dest.RestrictionsType, opt => opt.MapFrom(src => src.restrictionsType))
@@ -50,8 +52,6 @@ public class IndividualSearchMapper : Profile
             .ForMember(dest => dest.InsolvencyServiceAddress, opt => opt.MapFrom(src => src.insolvencyServiceAddress))
             .ForMember(dest => dest.InsolvencyServicePostcode, opt => opt.MapFrom(src => src.insolvencyServicePostcode))
             .ForMember(dest => dest.InsolvencyServiceTelephone, opt => opt.MapFrom(src => src.insolvencyServicePhone))
-            .ForMember(dest => dest.InsolvencyTradeName, opt => opt.MapFrom(src => src.tradingNames))
-            .ForMember(dest => dest.CaseDescription, opt => opt.MapFrom(src => src.caseDescription))
             .ForMember(dest => dest.CaseNumber, opt => opt.MapFrom(src => src.caseNo))
             .ForMember(dest => dest.IndividualNumber, opt => opt.MapFrom(src => src.indivNo))
             .ForMember(dest => dest.DateOfPreviousOrder, opt => opt.MapFrom(src => src.dateOfPreviousOrder))
@@ -59,14 +59,14 @@ public class IndividualSearchMapper : Profile
         .ReverseMap()
         .ForPath(s => s.Trading,
                 opt => opt.MapFrom(
-                    src => (!string.IsNullOrEmpty(src.InsolvencyTradeName) && src.InsolvencyTradeName != "<No Trading Names Found>")
-                        ? src.InsolvencyTradeName : null));
+                    src => (!string.IsNullOrEmpty(src.TradingData) && src.TradingData != "<No Trading Names Found>")
+                        ? src.TradingData : null));
 
         CreateMap<IndividualSearch, SearchResult>()
             .ForMember(m => m.individualForenames, opt => opt.MapFrom(s => s.FirstName))
             .ForMember(m => m.individualSurname, opt => opt.MapFrom(s => s.FamilyName))
             .ForMember(m => m.individualAlias, opt => opt.MapFrom(s => s.AlternativeNames))
-            .ForMember(m => m.companyName, opt => opt.MapFrom(s => s.InsolvencyTradeName))
+            .ForMember(m => m.companyName, opt => opt.MapFrom(s => s.TradingData))
             .ForMember(m => m.individualTown, opt => opt.MapFrom(s => s.LastKnownTown))
             .ForMember(m => m.individualPostcode, opt => opt.MapFrom(s => s.LastKnownPostcode))
             .ForMember(m => m.caseNo, opt => opt.MapFrom(s => s.CaseNumber))

--- a/INSS.EIIR.Models/IndexModels/IndividualSearch.cs
+++ b/INSS.EIIR.Models/IndexModels/IndividualSearch.cs
@@ -83,19 +83,18 @@ public class IndividualSearch
     [SimpleField(IsFilterable = true)]
     public string InsolvencyType { get; set; }
 
+    /// <summary>
+    /// InsolvencyDate contains the date in text form dd/MM/yyyy
+    /// At time of writing June 2024 there were no records on the register without an insolvency_date
+    /// </summary>
     [SimpleField(IsSortable = true)]
-    public DateTime StartDate { get; set; }
-
-    [SimpleField]
-    public DateTime EndDate { get; set; }
-
-    [SimpleField]
     public String InsolvencyDate { get; set; }
 
-
+    /// <summary>
+    /// Applies to IVAs
+    /// </summary>
     [SimpleField]
     public DateTime NotificationDate { get; set; }
-
 
     [SimpleField(IsFilterable = true)]
     public string CaseStatus { get; set; }
@@ -103,20 +102,27 @@ public class IndividualSearch
     [SimpleField]
     public string CaseDescription { get; set; }
 
+    /// <summary>
+    /// Contains an XML fragment with following structure
+    /// <Trading><TradingDetails><TradingName></TradingName><TradingAddress></TradingAddress></TradingDetails></Trading>
+    /// Where
+    ///     TradingName contains a value
+    ///     TradingAddress contains as value
+    ///     There can be mulitple <TradingDetails> elements - i.e muliptle names and addresses
+    /// OR
+    /// <No //Trading Names Found> //Don't know why but need to include "//" before Trading earlier in this comment line
+    /// </summary>
     [SearchableField(IsSortable = true)]
-    public string TradingName { get; set; }
+    public string TradingData { get; set; }
 
-    [SimpleField]
-    public string TradingAddress { get; set; }
+    /*          Restriction related fields - Start            */
 
-    [SimpleField]
-    public string TradingPostcode { get; set; }
-
-    //Restriction related fields
     [SimpleField]
     public Boolean HasRestrictions { get; set; }
 
-    //Expected values null, Interim Order, Order, Undertaking 
+    /// <summary>
+    /// Expected values null, Interim Order, Order, Undertaking 
+    /// </summary>
     [SimpleField]
     public string RestrictionsType { get; set; }
 
@@ -138,6 +144,8 @@ public class IndividualSearch
     //The end date of their previous Interim Restrictions Order
     [SimpleField]
     public DateTime? PrevInterimRestrictionsOrderEndDate { get; set; }
+
+    /*          Restriction related fields - End            */
 
     [SimpleField]
     public string PractitionerName { get; set; }
@@ -167,12 +175,7 @@ public class IndividualSearch
 
     [SimpleField]
     public string InsolvencyServiceTelephone { get; set; }
-
-    [SearchableField(IsSortable = true)]
-    public string InsolvencyTradeName { get; set; }
-
-    [SimpleField]
-    public string InsolvencyTradeNameAddress { get; set; }
+ 
     [SimpleField]
     public DateTime? DateOfPreviousOrder { get; set; }
     [SimpleField]


### PR DESCRIPTION
…e of property used to store trading data (e.g. tradingname and tradingaddress) from InsolvencyTradeName to TradingData to better represent it in terms of data usage within solution
