### PR TITLE
Bug/app 5144 base64 encode search term

### DIFF
--- a/INSS.EIIR.AzureSearch.Services/QueryServices/BaseQueryService.cs
+++ b/INSS.EIIR.AzureSearch.Services/QueryServices/BaseQueryService.cs
@@ -55,6 +55,7 @@ public abstract class BaseQueryService
     public async Task<IEnumerable<TR>> SearchIndexAsync<T, TR>(string searchTerm, SearchOptions options)
     {
 
+        //APP-5144 Base64 decode searchterm as certain characters were causing Barracuda WAF issues
         searchTerm = FormatSearchTerm(CleanSearchString(searchTerm.Base64Decode()));
 
         var searchClient = _indexClient.GetSearchClient(IndexName);

--- a/INSS.EIIR.AzureSearch.Services/QueryServices/BaseQueryService.cs
+++ b/INSS.EIIR.AzureSearch.Services/QueryServices/BaseQueryService.cs
@@ -4,6 +4,7 @@ using Azure.Search.Documents.Indexes;
 using Azure.Search.Documents.Models;
 using INSS.EIIR.Interfaces.AzureSearch;
 using INSS.EIIR.Models.CaseModels;
+using INSS.EIIR.Models.Helpers;
 
 namespace INSS.EIIR.AzureSearch.Services.QueryServices;
 
@@ -53,7 +54,8 @@ public abstract class BaseQueryService
 
     public async Task<IEnumerable<TR>> SearchIndexAsync<T, TR>(string searchTerm, SearchOptions options)
     {
-        searchTerm = FormatSearchTerm(CleanSearchString(searchTerm));
+
+        searchTerm = FormatSearchTerm(CleanSearchString(searchTerm.Base64Decode()));
 
         var searchClient = _indexClient.GetSearchClient(IndexName);
         var result = await searchClient.SearchAsync<T>(searchTerm, options);

--- a/INSS.EIIR.Models/Helpers/Base64Helper.cs
+++ b/INSS.EIIR.Models/Helpers/Base64Helper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace INSS.EIIR.Models.Helpers
+{
+    public static class Base64Helper
+    {
+
+        public static string Base64Encode(this string plainText)
+        {
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(plainText);
+            return System.Convert.ToBase64String(plainTextBytes);
+        }
+
+        public static string Base64Decode(this string base64EncodedData)
+        {
+            var base64EncodedBytes = System.Convert.FromBase64String(base64EncodedData);
+            return System.Text.Encoding.UTF8.GetString(base64EncodedBytes);
+        }
+
+    }
+}

--- a/INSS.EIIR.Web/Controllers/SearchController.cs
+++ b/INSS.EIIR.Web/Controllers/SearchController.cs
@@ -1,4 +1,5 @@
-﻿using INSS.EIIR.Models.Home;
+﻿using INSS.EIIR.Models.Helpers;
+using INSS.EIIR.Models.Home;
 using INSS.EIIR.Web.Helper;
 using Microsoft.AspNetCore.Mvc;
 
@@ -30,7 +31,7 @@ namespace INSS.EIIR.Web.Controllers
                 return RedirectToAction("Index", new { error = true });
             }
 
-            return RedirectToAction("Index", "SearchResults", new { searchTerm });
+            return RedirectToAction("Index", "SearchResults", new { searchTerm = searchTerm.Base64Encode() });
         }
     }
 }

--- a/INSS.EIIR.Web/Controllers/SearchController.cs
+++ b/INSS.EIIR.Web/Controllers/SearchController.cs
@@ -31,6 +31,7 @@ namespace INSS.EIIR.Web.Controllers
                 return RedirectToAction("Index", new { error = true });
             }
 
+            //APP-5144 Base64 encode searchterm as certain character cause Barracuda WAF issues
             return RedirectToAction("Index", "SearchResults", new { searchTerm = searchTerm.Base64Encode() });
         }
     }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ stages:
 
 - stage: DeploySit
   displayName: 'Deploy to Sit'
-  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'develop'))
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   variables:
     - group: EIIR-Sit
   jobs:


### PR DESCRIPTION
Hopefully fixes issue where certain characters **$ & + * ~ - \ / | > < . :**  in search term causing grief for Barracuda WAF 