### PR TITLE
APP-5362 Add header details including ExtractVolumes and Disclaimer

### DIFF
--- a/INSS.EIIR.DailyExtract/DI/SyncDataFactory.cs
+++ b/INSS.EIIR.DailyExtract/DI/SyncDataFactory.cs
@@ -33,6 +33,7 @@ namespace INSS.EIIR.DataSync.Functions.DI
             var mapper = sp.GetRequiredService<IMapper>();
             var indexMapper = sp.GetRequiredService<ISetIndexMapService>();
             var extractRepo = sp.GetRequiredService<IExtractRepository>();
+            var exBankruptcyService = sp.GetRequiredService<IExistingBankruptciesService>();
 
             IEnumerable<IDataSourceAsync<InsolventIndividualRegisterModel>> sources;
 
@@ -58,7 +59,7 @@ namespace INSS.EIIR.DataSync.Functions.DI
             IEnumerable<IDataSink<InsolventIndividualRegisterModel>> sinks = new List<IDataSink<InsolventIndividualRegisterModel>>()
             {
                 GetAISearchSink(config, mapper, indexMapper, factory.CreateLogger<AISearchSink>()),
-                GetXMLSink(config, extractRepo)               
+                GetXMLSink(config, extractRepo, exBankruptcyService)               
             };
 
             IEnumerable<ITransformRule> transformRules = new List<ITransformRule>();           
@@ -77,7 +78,7 @@ namespace INSS.EIIR.DataSync.Functions.DI
             return new SyncData(options, factory.CreateLogger<SyncData>());
         }
 
-        private static IDataSink<InsolventIndividualRegisterModel> GetXMLSink(IConfiguration config, IExtractRepository repo)
+        private static IDataSink<InsolventIndividualRegisterModel> GetXMLSink(IConfiguration config, IExtractRepository repo, IExistingBankruptciesService service)
         {
             var options = new XMLSinkOptions()
             {
@@ -86,7 +87,7 @@ namespace INSS.EIIR.DataSync.Functions.DI
                 WriteToBlobRecordBufferSize = config.GetValue<int>("SyncDataWriteXMLBufferSize", 500)
             };
 
-            return new XMLSink(options, repo);
+            return new XMLSink(options, repo, service);
         }
 
         private static IDataSink<InsolventIndividualRegisterModel> GetAISearchSink(IConfiguration config, IMapper mapper, ISetIndexMapService indexMapper, ILogger<AISearchSink> logger)

--- a/INSS.EIIR.DailyExtract/Program.cs
+++ b/INSS.EIIR.DailyExtract/Program.cs
@@ -14,6 +14,7 @@ using INSS.EIIR.Models.AutoMapperProfiles;
 using INSS.EIIR.DataSync.Application.UseCase.SyncData.AutoMapperProfiles;
 using INSS.EIIR.DataSync.Infrastructure.Source.SQL.Models.AutoMapperProfiles;
 using INSS.EIIR.AzureSearch.IndexMapper;
+using INSS.EIIR.DataSync.Infrastructure.Sink.XML;
 using INSS.EIIR.Interfaces.DataAccess;
 using INSS.EIIR.DataAccess;
 using INSS.EIIR.Models.Configuration;
@@ -30,6 +31,11 @@ var host = new HostBuilder()
         services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 
         services.AddSetIndexMapper(new IndexMapperOptions()
+        {
+            TableStorageConnectionString = Environment.GetEnvironmentVariable("TableStorageConnectionString")
+        });
+
+        services.AddExistingBankrupticesService(new ExistingBankruptciesOptions()
         {
             TableStorageConnectionString = Environment.GetEnvironmentVariable("TableStorageConnectionString")
         });

--- a/INSS.EIIR.DataSync.Infrastructure/Sink/XML/ExistingBankruptciesOptions.cs
+++ b/INSS.EIIR.DataSync.Infrastructure/Sink/XML/ExistingBankruptciesOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace INSS.EIIR.DataSync.Infrastructure.Sink.XML
+{
+    public class ExistingBankruptciesOptions
+    {
+        public string TableStorageConnectionString { get; set; }
+    }
+}

--- a/INSS.EIIR.DataSync.Infrastructure/Sink/XML/ExistingBankruptciesService.cs
+++ b/INSS.EIIR.DataSync.Infrastructure/Sink/XML/ExistingBankruptciesService.cs
@@ -1,0 +1,75 @@
+﻿using Azure;
+using Azure.Data.Tables;
+using INSS.EIIR.AzureSearch.IndexMapper;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace INSS.EIIR.DataSync.Infrastructure.Sink.XML
+{
+    public class ExistingBankruptciesService : IExistingBankruptciesService
+    {
+        public const string EX_BANK_TABLE_NAME = "ExistingBankruptcies";
+        public const string EX_BANK_PARTITION_KEY = "existingbankruptcies_partition_key";
+        public const string EX_BANK_ROW_KEY = "existingbankruptcies_row_key";
+        public const string EX_BANK_PROPERTY_NAME = "bankruptcy_ids_json";
+
+
+        private TableClient _tableClient;
+
+        public ExistingBankruptciesService(ExistingBankruptciesOptions options) 
+        {
+            _tableClient = new TableClient(
+                options.TableStorageConnectionString,
+                EX_BANK_TABLE_NAME,
+                new TableClientOptions()
+                {
+                    Retry =
+                    {
+                        MaxRetries = 5,
+                        Delay = TimeSpan.FromSeconds(2),
+                        Mode = Azure.Core.RetryMode.Exponential
+                    }
+                }
+            );
+        }
+
+        async Task<SortedList<int, int>> IExistingBankruptciesService.GetExistingBankruptcies()
+        {
+            var defaultReturn = new SortedList<int, int>(); 
+
+            try
+            {
+                var entityResponse = await _tableClient.GetEntityAsync<TableEntity>(EX_BANK_PARTITION_KEY, EX_BANK_ROW_KEY);
+                var entity = entityResponse.Value;
+                return JsonSerializer.Deserialize<SortedList<int, int>>(entity[EX_BANK_PROPERTY_NAME].ToString());
+            }
+            //If entity doesn't exist return the default
+            catch (RequestFailedException)
+            {
+                return defaultReturn;
+            }
+        }
+
+        async Task IExistingBankruptciesService.SetExistingBankruptcies(SortedList<int, int> existingBankruptcies)
+        {
+            var table = await _tableClient.CreateIfNotExistsAsync();
+            var indexMapEntity = new TableEntity(EX_BANK_PARTITION_KEY, EX_BANK_ROW_KEY)
+            {
+                { EX_BANK_PROPERTY_NAME, JsonSerializer.Serialize(existingBankruptcies) }
+            };
+
+            try
+            {
+                await _tableClient.UpsertEntityAsync(indexMapEntity);
+            }
+            catch (RequestFailedException)
+            {
+                throw new Exception($"Failed to save existing bankruptcy identifiers");
+            }
+        }
+    }
+}

--- a/INSS.EIIR.DataSync.Infrastructure/Sink/XML/ExistingBankruptciesServiceExtension.cs
+++ b/INSS.EIIR.DataSync.Infrastructure/Sink/XML/ExistingBankruptciesServiceExtension.cs
@@ -1,0 +1,21 @@
+﻿using INSS.EIIR.AzureSearch.IndexMapper;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace INSS.EIIR.DataSync.Infrastructure.Sink.XML
+{
+    public static class ExistingBankruptciesServiceExtension
+    {
+        public static IServiceCollection AddExistingBankrupticesService(this IServiceCollection services, ExistingBankruptciesOptions options)
+        {
+            services.AddSingleton<IExistingBankruptciesService>(new ExistingBankruptciesService(options));
+
+            return services;
+        }
+
+    }
+}

--- a/INSS.EIIR.DataSync.Infrastructure/Sink/XML/ExtractVolumes.cs
+++ b/INSS.EIIR.DataSync.Infrastructure/Sink/XML/ExtractVolumes.cs
@@ -1,0 +1,26 @@
+﻿namespace INSS.EIIR.DataSync.Infrastructure.Sink.XML
+{
+    public class ExtractVolumes
+    {
+        private int _totalEntries;
+        private int _totalBanks;
+        private int _totalIVAs;
+        private int _newBanks;
+        private int _totalDros;
+
+        public ExtractVolumes() 
+        { 
+            _totalEntries = 0;
+            _totalBanks = 0;
+            _totalIVAs = 0;
+            _newBanks = 0;
+            _totalDros = 0;
+        }
+
+        public int TotalEntries { get => _totalEntries; internal set => _totalEntries = value; }
+        public int TotalBanks { get => _totalBanks; internal set => _totalBanks = value; }
+        public int TotalIVAs { get => _totalIVAs; internal set => _totalIVAs = value; }
+        public int NewBanks { get => _newBanks; internal set => _newBanks = value; }
+        public int TotalDros { get => _totalDros; internal set => _totalDros = value; }
+    }
+}

--- a/INSS.EIIR.DataSync.Infrastructure/Sink/XML/IExistingBankruptciesService.cs
+++ b/INSS.EIIR.DataSync.Infrastructure/Sink/XML/IExistingBankruptciesService.cs
@@ -1,0 +1,11 @@
+﻿
+namespace INSS.EIIR.DataSync.Infrastructure.Sink.XML
+{
+    public interface IExistingBankruptciesService
+    {
+        Task<SortedList<int, int>> GetExistingBankruptcies();
+
+        Task SetExistingBankruptcies(SortedList<int, int> existingBankruptcies);
+    }
+
+}

--- a/INSS.EIIR.DataSync.Infrastructure/Sink/XML/IirXMLWriterHelper.cs
+++ b/INSS.EIIR.DataSync.Infrastructure/Sink/XML/IirXMLWriterHelper.cs
@@ -1,11 +1,20 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Concurrent;
+using System;
+using System.Diagnostics;
 using System.Globalization;
+using System.Numerics;
+using System.Reflection;
+using System.Security.Principal;
 using System.Text;
 using System.Xml;
 using INSS.EIIR.DataSync.Application.UseCase.SyncData.Model;
 using INSS.EIIR.Models.CaseModels;
 using INSS.EIIR.Models.Constants;
 using Microsoft.IdentityModel.Abstractions;
+using Newtonsoft.Json.Linq;
+using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace INSS.EIIR.DataSync.Infrastructure.Sink.XML
 {
@@ -534,22 +543,47 @@ namespace INSS.EIIR.DataSync.Infrastructure.Sink.XML
             }
         }
 
-        public static void WriteIirHeaderToStream(ref MemoryStream? xmlStream)
+        public static void WriteIirHeaderToStream(ref MemoryStream? xmlStream, ExtractVolumes ev)
         {
             XmlWriterSettings settings = new XmlWriterSettings();
-            settings.OmitXmlDeclaration = true;
+            settings.OmitXmlDeclaration = false;
             settings.Encoding = new UTF8Encoding(false);
             settings.ConformanceLevel = ConformanceLevel.Fragment;
-            
-
             using (XmlWriter writer = XmlWriter.Create(xmlStream, settings))
             {
                 writer.WriteRaw("<ReportDetails>");
+
+                writer.WriteStartElement(null, "ExtractVolumes", null );
+
+                writer.WriteStartElement(null, "TotalEntries", null);
+                writer.WriteString($"{ev.TotalEntries}");
+                writer.WriteEndElement();
+
+                writer.WriteStartElement(null, "TotalBanks", null);
+                writer.WriteString($"{ev.TotalBanks}");
+                writer.WriteEndElement();
+
+                writer.WriteStartElement(null, "TotalIVAs", null);
+                writer.WriteString($"{ev.TotalIVAs}");
+                writer.WriteEndElement();
+
+                writer.WriteStartElement(null, "NewBanks", null);
+                writer.WriteString($"{ev.NewBanks}");
+                writer.WriteEndElement();
+
+                writer.WriteStartElement(null, "TotalDros", null);
+                writer.WriteString($"{ev.TotalDros}");
+                writer.WriteEndElement();
+
+                writer.WriteEndElement();
+
+                writer.WriteStartElement(null, "Disclaimer", null);
+                writer.WriteString($"While every effort has been made to ensure that the information provided is accurate, occasionally errors may occur. If you identify information which appears to be incorrect or omitted, please inform The Insolvency Service so that we can investigate the matter and correct the database as required.The Insolvency Case Details are taken from the Court Order made on the Order Date, and include the address(es) from which debts were incurred.They cannot be changed without the consent of the Court. The Individual Details may have changed since the Court Order but, even so, they might not reflect the person's current address or occupation at the time you make your search, and they should not be relied on as such. The Insolvency Service cannot accept responsibility for any errors or omissions as a result of negligence or otherwise. Please note that The Insolvency Service and Official Receivers cannot provide legal or financial advice. You should seek this from a Citizen's Advice Bureau, a solicitor, a qualified accountant, an authorised Insolvency Practitioner, reputable financial advisor or advice centre. The Individual Insolvency Register is a publicly available register and The Insolvency Service does not endorse, nor make any representations regarding, any use made of the data on the register by third parties.");
+                writer.WriteEndElement();
+
                 writer.Flush();
             }
         }
-
-
         public static void WriteIirFooterToStream(ref MemoryStream? xmlStream)
         {
             XmlWriterSettings settings = new XmlWriterSettings();


### PR DESCRIPTION
Adds header elements
- ExtractVolumes
- Disclaimer

By counting records as they are added to the XML sink, NewBanks utilises new Azure Table storage to maintain a list of previously loaded bankruptcies, if it is not in this list... it is a new bankruptcy.
