### PR TITLE
Feature/app 5309 remove viewed feedback

### DIFF
--- a/INSS.EIIR.Functions.Tests/FeedbackIntegrationTests.cs
+++ b/INSS.EIIR.Functions.Tests/FeedbackIntegrationTests.cs
@@ -5,6 +5,7 @@ using INSS.EIIR.DataAccess;
 using INSS.EIIR.Functions.Functions;
 using INSS.EIIR.Interfaces.DataAccess;
 using INSS.EIIR.Interfaces.Services;
+using INSS.EIIR.Interfaces;
 using INSS.EIIR.Models.Configuration;
 using INSS.EIIR.Models.FeedbackModels;
 using INSS.EIIR.Services;
@@ -34,6 +35,7 @@ namespace INSS.EIIR.Functions.Tests
         private readonly EIIRContext _context;
         private readonly FeedbackRepository _feedbackRepository;
         private readonly FeedbackDataProvider _feedbackDataProvider;
+        private readonly ISystemDateTime _systemDateTime;
         private readonly IMapper _mapper;
 
         public FeedbackIntegrationTests()
@@ -55,7 +57,8 @@ namespace INSS.EIIR.Functions.Tests
             _connectionString = config.GetConnectionString("iirwebdbContextConnectionString");
             _context = new EIIRContext(_connectionString);
             _feedbackRepository = new FeedbackRepository(_context, _mapper);
-            _feedbackDataProvider = new FeedbackDataProvider(_feedbackRepository);
+            _systemDateTime = new SystemDateTime();
+            _feedbackDataProvider = new FeedbackDataProvider(_feedbackRepository, _systemDateTime);
         }
 
         [Fact (Skip = "Expensive integration test, dependency on appsettings.json .. which perhaps not available in github")]

--- a/INSS.EIIR.Functions/Program.cs
+++ b/INSS.EIIR.Functions/Program.cs
@@ -14,6 +14,7 @@ using INSS.EIIR.Interfaces.DataAccess;
 using INSS.EIIR.Interfaces.Messaging;
 using INSS.EIIR.Interfaces.Services;
 using INSS.EIIR.Interfaces.Storage;
+using INSS.EIIR.Interfaces;
 using INSS.EIIR.Models.AutoMapperProfiles;
 using INSS.EIIR.Models.Configuration;
 using INSS.EIIR.Services;
@@ -148,6 +149,7 @@ var host = new HostBuilder()
         services.AddScoped<ISubscriberDataProvider, SubscriberDataProvider>();
         services.AddScoped<INotificationService, NotificationService>();
         services.AddScoped<IFeedbackDataProvider, FeedbackDataProvider>();
+        services.AddSingleton<ISystemDateTime, SystemDateTime>();
 
 
         Boolean useFakeData = false;

--- a/INSS.EIIR.Interfaces/ISystemDateTime.cs
+++ b/INSS.EIIR.Interfaces/ISystemDateTime.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace INSS.EIIR.Interfaces
+{
+    public interface ISystemDateTime
+    {
+        DateTime Now { get; }
+    }
+}

--- a/INSS.EIIR.Models/Constants/Role.cs
+++ b/INSS.EIIR.Models/Constants/Role.cs
@@ -47,3 +47,8 @@ public static class SyncData
 {
     public const string ContainsNonPermittedData = "contains-non-permitted-data";
 }
+
+public static class Feedback
+{
+    public const int SoftDeleteFeedbackAfterDays = 30;
+}

--- a/INSS.EIIR.Models/Constants/Role.cs
+++ b/INSS.EIIR.Models/Constants/Role.cs
@@ -50,5 +50,5 @@ public static class SyncData
 
 public static class Feedback
 {
-    public const int SoftDeleteFeedbackAfterDays = 30;
+    public const int SoftDeleteFeedbackAfterDaysDefault = 30;
 }

--- a/INSS.EIIR.Models/FeedbackModels/FeedbackFilterModel.cs
+++ b/INSS.EIIR.Models/FeedbackModels/FeedbackFilterModel.cs
@@ -1,10 +1,11 @@
 ﻿using System.Runtime.Serialization;
+using INSS.EIIR.Models.Constants;   
 
 namespace INSS.EIIR.Models.FeedbackModels
 {
     public class FeedbackFilterModel
     {
-        private int _softDeleteViewedAfterDays = 30;
+        private int _softDeleteViewedAfterDays = Feedback.SoftDeleteFeedbackAfterDays;
 
         public string Status { get; set; }
 

--- a/INSS.EIIR.Models/FeedbackModels/FeedbackFilterModel.cs
+++ b/INSS.EIIR.Models/FeedbackModels/FeedbackFilterModel.cs
@@ -5,7 +5,7 @@ namespace INSS.EIIR.Models.FeedbackModels
 {
     public class FeedbackFilterModel
     {
-        private int _softDeleteViewedAfterDays = Feedback.SoftDeleteFeedbackAfterDays;
+        private int _softDeleteViewedAfterDays = Feedback.SoftDeleteFeedbackAfterDaysDefault;
 
         public string Status { get; set; }
 

--- a/INSS.EIIR.Models/FeedbackModels/FeedbackFilterModel.cs
+++ b/INSS.EIIR.Models/FeedbackModels/FeedbackFilterModel.cs
@@ -4,11 +4,26 @@ namespace INSS.EIIR.Models.FeedbackModels
 {
     public class FeedbackFilterModel
     {
+        private int _softDeleteViewedAfterDays = 30;
+
         public string Status { get; set; }
 
         public string Organisation { get; set; }   
         
         public string InsolvencyType { get; set; }
+
+        public int SoftDeleteViewedRecordsAfterDays
+        {
+            get
+            { 
+                return _softDeleteViewedAfterDays;
+            }
+
+            set 
+            {
+                _softDeleteViewedAfterDays = value;
+            } 
+        }
     }
 
     public enum ViewFilter

--- a/INSS.EIIR.Services.Tests/FeedbackDataProviderTests.cs
+++ b/INSS.EIIR.Services.Tests/FeedbackDataProviderTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using AutoMapper.Configuration.Annotations;
+using FluentAssertions;
 using INSS.EIIR.Data.Models;
 using INSS.EIIR.Interfaces.DataAccess;
 using INSS.EIIR.Models.Configuration;
@@ -13,34 +14,39 @@ namespace INSS.EIIR.Services.Tests
     public class FeedbackDataProviderTests
     {
         [Theory]
-        [InlineData("All", null, null)]
-        [InlineData("Viewed", null, null)]
-        [InlineData("Unviewed", null, null)]
-        [InlineData("All", "Member of the public", null)]
-        [InlineData("Viewed", "Financial services", null)]
-        [InlineData("Unviewed", "Government department", null)]
-        [InlineData("All", "Member of the public", "I")]
-        [InlineData("Viewed", "Financial services", "B")]
-        [InlineData("Unviewed", "Government department", "D")]
-        public async Task GetFeedback_WithFilters(string viewedStatus, string organisation, string insolvencyType)
+        [InlineData("All", null, null, 6, 8)]
+        [InlineData("Viewed", null, null, 6, 1)]
+        [InlineData("Unviewed", null, null, 6, 7)]
+        [InlineData("All", "Member of the public", null, 6, 3)]
+        [InlineData("Viewed", "Financial services", null, 6, 0)]
+        [InlineData("Unviewed", "Government department", null, 6, 2)]
+        [InlineData("All", "Member of the public", "I", 6, 1)]
+        [InlineData("Viewed", "Financial services", "B", 6, 0)]
+        [InlineData("Unviewed", "Government department", "D", 6, 1)]
+        public async Task GetFeedback_WithFilters(string viewedStatus, string organisation, string insolvencyType, int softDelete, int recordCount)
         {
             var expectedResult = GetCaseFeedback();
             var feedbackBody = new FeedbackBody() { 
                 PagingModel = new PagingParameters { PageNumber = 1, PageSize = 10 }, 
-                Filters = new FeedbackFilterModel { Status = viewedStatus, Organisation = organisation, InsolvencyType = insolvencyType } 
+                Filters = new FeedbackFilterModel { Status = viewedStatus, Organisation = organisation, InsolvencyType = insolvencyType, SoftDeleteViewedRecordsAfterDays = softDelete } 
             };
             var repositoryMock = new Mock<IFeedbackRepository>();
             repositoryMock
                 .Setup(m => m.GetFeedbackAsync())
                 .ReturnsAsync(expectedResult);
 
-            var service = new FeedbackDataProvider(repositoryMock.Object);
+            var systemDateTimeMock = new Mock<Interfaces.ISystemDateTime>();
+            systemDateTimeMock
+                .Setup(m => m.Now)
+                .Returns(new DateTime(2022, 10, 30, 14, 25, 10));
+
+            var service = new FeedbackDataProvider(repositoryMock.Object, systemDateTimeMock.Object);
 
             var result = (await service.GetFeedbackAsync(feedbackBody)).Feedback.ToList();
 
             repositoryMock.Verify(m => m.GetFeedbackAsync(), Times.Once);
 
-            result.Count.Should().Be(result.Count);
+            result.Count.Should().Be(recordCount);
         }
 
         [Fact]
@@ -48,10 +54,11 @@ namespace INSS.EIIR.Services.Tests
         {
             var data = new CreateCaseFeedback();
             var repositoryMock = new Mock<IFeedbackRepository>();
+            var systemDateTimeMock = new Mock<Interfaces.ISystemDateTime>();    
 
             repositoryMock.Setup(m => m.CreateFeedback(data));
 
-            var service = new FeedbackDataProvider(repositoryMock.Object);
+            var service = new FeedbackDataProvider(repositoryMock.Object, systemDateTimeMock.Object);
 
             service.CreateFeedback(data);
 
@@ -65,12 +72,13 @@ namespace INSS.EIIR.Services.Tests
             var viewedStatus = true;
             var expectedResult = new CaseFeedback() { CaseId = 12345, FeedbackDate = DateTime.Now };
             var repositoryMock = new Mock<IFeedbackRepository>();
+            var systemDateTimeMock = new Mock<Interfaces.ISystemDateTime>();
             var contextMock = new Mock<EIIRContext>();
             contextMock.Setup(x => x.Add(expectedResult));
 
             repositoryMock.Setup(m => m.UpdateFeedbackStatus(feedbackId, viewedStatus)).Returns(true);
 
-            var service = new FeedbackDataProvider(repositoryMock.Object);
+            var service = new FeedbackDataProvider(repositoryMock.Object, systemDateTimeMock.Object);
 
             var result = service.UpdateFeedbackStatus(feedbackId, viewedStatus);
 

--- a/INSS.EIIR.Services/FeedbackDataProvider.cs
+++ b/INSS.EIIR.Services/FeedbackDataProvider.cs
@@ -1,5 +1,6 @@
 ﻿using INSS.EIIR.Interfaces.DataAccess;
 using INSS.EIIR.Interfaces.Services;
+using INSS.EIIR.Interfaces;
 using INSS.EIIR.Models.FeedbackModels;
 using INSS.EIIR.Models.Helpers;
 
@@ -8,10 +9,12 @@ namespace INSS.EIIR.Services
     public class FeedbackDataProvider : IFeedbackDataProvider
     {
         private readonly IFeedbackRepository _feedbackRepository;
+        private readonly ISystemDateTime _systemDateTime;   
 
-        public FeedbackDataProvider(IFeedbackRepository feedbackRepository)
+        public FeedbackDataProvider(IFeedbackRepository feedbackRepository, ISystemDateTime systemDateTime)
         {
             _feedbackRepository = feedbackRepository;
+            _systemDateTime = systemDateTime;
         }
 
         public async Task<FeedbackWithPaging> GetFeedbackAsync(FeedbackBody feedbackBody)
@@ -30,11 +33,15 @@ namespace INSS.EIIR.Services
             }
             var organisation = feedbackBody?.Filters?.Organisation;
             var insolvencyType = feedbackBody?.Filters?.InsolvencyType;
+            var softDeleteDays = feedbackBody?.Filters?.SoftDeleteViewedRecordsAfterDays ?? 30;
+
+            var softDeleteCutOff = _systemDateTime.Now.AddDays(-1 * (softDeleteDays + 1)).Date;
 
             var totalFeedback = (await _feedbackRepository.GetFeedbackAsync())
                                     .Where(x => x.Viewed.Equals(viewedStatus) || viewedStatus is null)
                                     .Where(x => x.ReporterOrganisation.Equals(organisation) || string.IsNullOrEmpty(organisation))
-                                    .Where(x => x.InsolvencyType.Equals(insolvencyType) || string.IsNullOrEmpty(insolvencyType)).ToList();
+                                    .Where(x => x.InsolvencyType.Equals(insolvencyType) || string.IsNullOrEmpty(insolvencyType))
+                                    .Where(x => x.Viewed.Equals(false) || (x.Viewed.Equals(true) && x.ViewedDate > softDeleteCutOff)).ToList();
 
             var pagedFeedback = totalFeedback
                                     .Skip(feedbackBody.PagingModel.Skip)

--- a/INSS.EIIR.Services/FeedbackDataProvider.cs
+++ b/INSS.EIIR.Services/FeedbackDataProvider.cs
@@ -3,6 +3,7 @@ using INSS.EIIR.Interfaces.Services;
 using INSS.EIIR.Interfaces;
 using INSS.EIIR.Models.FeedbackModels;
 using INSS.EIIR.Models.Helpers;
+using INSS.EIIR.Models.Constants;
 
 namespace INSS.EIIR.Services
 {
@@ -33,7 +34,7 @@ namespace INSS.EIIR.Services
             }
             var organisation = feedbackBody?.Filters?.Organisation;
             var insolvencyType = feedbackBody?.Filters?.InsolvencyType;
-            var softDeleteDays = feedbackBody?.Filters?.SoftDeleteViewedRecordsAfterDays ?? 30;
+            var softDeleteDays = feedbackBody?.Filters?.SoftDeleteViewedRecordsAfterDays ?? Feedback.SoftDeleteFeedbackAfterDays;
 
             var softDeleteCutOff = _systemDateTime.Now.AddDays(-1 * (softDeleteDays + 1)).Date;
 

--- a/INSS.EIIR.Services/FeedbackDataProvider.cs
+++ b/INSS.EIIR.Services/FeedbackDataProvider.cs
@@ -34,7 +34,7 @@ namespace INSS.EIIR.Services
             }
             var organisation = feedbackBody?.Filters?.Organisation;
             var insolvencyType = feedbackBody?.Filters?.InsolvencyType;
-            var softDeleteDays = feedbackBody?.Filters?.SoftDeleteViewedRecordsAfterDays ?? Feedback.SoftDeleteFeedbackAfterDays;
+            var softDeleteDays = feedbackBody?.Filters?.SoftDeleteViewedRecordsAfterDays ?? Feedback.SoftDeleteFeedbackAfterDaysDefault;
 
             var softDeleteCutOff = _systemDateTime.Now.AddDays(-1 * (softDeleteDays + 1)).Date;
 

--- a/INSS.EIIR.Services/SystemDateTime.cs
+++ b/INSS.EIIR.Services/SystemDateTime.cs
@@ -1,0 +1,14 @@
+﻿using INSS.EIIR.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace INSS.EIIR.Services
+{
+    public class SystemDateTime : ISystemDateTime
+    {
+        public DateTime Now => DateTime.Now;
+    }
+}

--- a/INSS.EIIR.Web/Areas/Admin/Controllers/ErrorsIssuesController.cs
+++ b/INSS.EIIR.Web/Areas/Admin/Controllers/ErrorsIssuesController.cs
@@ -77,9 +77,9 @@ namespace INSS.EIIR.Web.Areas.Admin.Controllers
 
         private int GetSoftDeleteDays()
         {
-            var setting = _config.GetValue<object>("SoftDeleteViewedRecordsAfterDays", 30);
+            var setting = _config.GetValue<object>("SoftDeleteViewedRecordsAfterDays", Feedback.SoftDeleteFeedbackAfterDays);
 
-            int value = 30;
+            int value = Feedback.SoftDeleteFeedbackAfterDays;
 
             if (int.TryParse(setting.ToString(), out int result))
             { 

--- a/INSS.EIIR.Web/Areas/Admin/Controllers/ErrorsIssuesController.cs
+++ b/INSS.EIIR.Web/Areas/Admin/Controllers/ErrorsIssuesController.cs
@@ -7,6 +7,7 @@ using INSS.EIIR.Web.Helper;
 using INSS.EIIR.Web.ViewModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using NuGet.Frameworks;
 
 namespace INSS.EIIR.Web.Areas.Admin.Controllers
 {
@@ -15,10 +16,12 @@ namespace INSS.EIIR.Web.Areas.Admin.Controllers
     public class ErrorsIssuesController : Controller
     {
         private readonly IErrorIssuesService _errorIssuesService;
+        private readonly IConfiguration _config;
 
-        public ErrorsIssuesController(IErrorIssuesService errorIssuesService)
+        public ErrorsIssuesController(IConfiguration config, IErrorIssuesService errorIssuesService)
         {
             _errorIssuesService = errorIssuesService;
+            _config = config;
         }
 
         [HttpGet(AreaNames.Admin + "/errors-or-issues/{page?}/{insolvencyType?}/{organisation?}/{status?}")]
@@ -50,7 +53,7 @@ namespace INSS.EIIR.Web.Areas.Admin.Controllers
             return RedirectToAction("Index", new { page = 1, insolvencyType, organisation, status });
         }
 
-        private static FeedbackBody CreateParameters(int page, string insolvencyType, int organisation, int status)
+        private FeedbackBody CreateParameters(int page, string insolvencyType, int organisation, int status)
         {
             var parameters = new FeedbackBody
             {
@@ -58,7 +61,9 @@ namespace INSS.EIIR.Web.Areas.Admin.Controllers
                 {
                     InsolvencyType = insolvencyType == "A" ? string.Empty : insolvencyType,
                     Organisation = organisation == 0 ? string.Empty : FeedbackFilters.OrganisationFilters[organisation],
-                    Status = status == 1 ? "Unviewed" : FeedbackFilters.StatusFilters[status]
+                    Status = status == 1 ? "Unviewed" : FeedbackFilters.StatusFilters[status],
+                    SoftDeleteViewedRecordsAfterDays = this.GetSoftDeleteDays()
+
                 },
                 PagingModel = new PagingParameters
                 {
@@ -68,6 +73,20 @@ namespace INSS.EIIR.Web.Areas.Admin.Controllers
             };
 
             return parameters;
+        }
+
+        private int GetSoftDeleteDays()
+        {
+            var setting = _config.GetValue<object>("SoftDeleteViewedRecordsAfterDays", 30);
+
+            int value = 30;
+
+            if (int.TryParse(setting.ToString(), out int result))
+            { 
+                value = result;
+            }
+
+            return value;
         }
     }
 }

--- a/INSS.EIIR.Web/Areas/Admin/Controllers/ErrorsIssuesController.cs
+++ b/INSS.EIIR.Web/Areas/Admin/Controllers/ErrorsIssuesController.cs
@@ -77,9 +77,9 @@ namespace INSS.EIIR.Web.Areas.Admin.Controllers
 
         private int GetSoftDeleteDays()
         {
-            var setting = _config.GetValue<object>("SoftDeleteViewedRecordsAfterDays", Feedback.SoftDeleteFeedbackAfterDays);
+            var setting = _config.GetValue<object>("SoftDeleteViewedRecordsAfterDays", Feedback.SoftDeleteFeedbackAfterDaysDefault);
 
-            int value = Feedback.SoftDeleteFeedbackAfterDays;
+            int value = Feedback.SoftDeleteFeedbackAfterDaysDefault;
 
             if (int.TryParse(setting.ToString(), out int result))
             { 

--- a/INSS.EIIR.Web/appsettings-template.json
+++ b/INSS.EIIR.Web/appsettings-template.json
@@ -15,5 +15,7 @@
     "ApiKey": ""
   },
   "AllowedHosts": "*",
+  //Optional - The number of days after which Viewed feedback records are soft deleted
+  "SoftDeleteViewedRecordsAfterDays": 30,
   "APPLICATIONINSIGHTS_CONNECTION_STRING": "__APPLICATIONINSIGHTS_CONNECTION_STRING__"
 }


### PR DESCRIPTION
The initial part of APP-5309 which implements a software delete of viewed feedback records > 30 (default) days ago.  Some things to look out for:

- Extends existing filter model use by front  end to filter and sort records... the soft delete just ends up extending the filter
- Unit test for filter improved to actually test the returned records counts
- Encapsulation of DateTime.Now in an ISystemDateTime - to allow for unit testing :)   